### PR TITLE
fixed KNORA E and KNORA U

### DIFF
--- a/brew/selection/dynamic/knora.py
+++ b/brew/selection/dynamic/knora.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import numpy as np
 
 from sklearn.ensemble import BaggingClassifier
@@ -18,6 +20,20 @@ class KNORA(DCS):
         y_nn = self.yval[idx] # k neighbors target
 
         return X_nn, y_nn
+
+
+    def _get_best_classifiers(self, ensemble, neighbors_X, neighbors_y, x):
+        ensemble_out = ensemble.output(neighbors_X, mode='labels')
+        ensemble_mask = ensemble_out == neighbors_y[:,np.newaxis]
+
+        correct = np.sum(ensemble_mask, axis=0)
+        idx = np.argmax(correct) # best classifier idx
+
+        all_idx = correct == correct[idx]
+        
+        pool = [ensemble.classifiers[i] for i in all_idx]
+
+        return pool
 
     
 class KNORA_ELIMINATE(KNORA):
@@ -74,7 +90,22 @@ class KNORA_ELIMINATE(KNORA):
     Ko, Albert HR, Robert Sabourin, and Alceu Souza Britto Jr. 
     "From dynamic classifier selection to dynamic ensemble selection." 
     Pattern Recognition 41.5 (2008): 1718-1731.
+
+    Britto, Alceu S., Robert Sabourin, and Luiz ES Oliveira. 
+    "Dynamic selection of classifiers—A comprehensive review."
+    Pattern Recognition 47.11 (2014): 3665-3680.
+
+    Hung-Ren Ko, A., Robert Sabourin, and A. de Souza Britto.
+    "K-nearest oracle for dynamic ensemble selection."
+    Document Analysis and Recognition, 2007. ICDAR 2007.
+    Ninth International Conference on. Vol. 1. IEEE, 2007
+
     """
+    def __init__(self, Xval, yval, K=5, weighted=False, knn=None, v2007=False):
+        self.v2007 = v2007
+        super(KNORA_ELIMINATE, self).__init__(Xval, yval, K=K, weighted=weighted, knn=knn)
+
+
     def select(self, ensemble, x):
         ensemble_mask = None
 
@@ -94,16 +125,17 @@ class KNORA_ELIMINATE(KNORA):
         # if NO classifiers get the nearest neighbor correctly
         if ensemble_mask is None:
            
-            # Increase neighborhood until one classifier
-            # gets at least ONE (i.e. ANY) neighbors correctly. 
-            # Starts with 2 because mask_all with k=1 is 
-            # the same as mask_any with k=1
-            for i in range(2, self.K+1):
-                pool_mask = _get_pool_mask(pool_output[:i], neighbors_y[:i], np.any)
+            if self.v2007:
+                # Increase neighborhood until one classifier
+                # gets at least ONE (i.e. ANY) neighbors correctly. 
+                # Starts with 2 because mask_all with k=1 is 
+                # the same as mask_any with k=1
+                for i in range(2, self.K+1):
+                    pool_mask = _get_pool_mask(pool_output[:i], neighbors_y[:i], np.any)
 
-                if pool_mask is not None:
-                    ensemble_mask = pool_mask
-                    break
+                    if pool_mask is not None:
+                        ensemble_mask = pool_mask
+                        break
 
         [selected_idx] = np.where(ensemble_mask)
 
@@ -111,7 +143,9 @@ class KNORA_ELIMINATE(KNORA):
             pool = Ensemble(classifiers=[ensemble.classifiers[i] for i in selected_idx])
 
         else: # use all classifiers
-            pool = ensemble
+            #pool = ensemble
+            classifiers = self._get_best_classifiers(ensemble, neighbors_X, neighbors_y, x)
+            pool = Ensemble(classifiers=classifiers)
 
 
         # KNORA-ELIMINATE-W that supposedly uses weights, does not make
@@ -119,51 +153,6 @@ class KNORA_ELIMINATE(KNORA):
         # None for the weights
 
         return pool, None
-
-
-class KNORA_ELIMINATE_2(KNORA):
-    def select(self, ensemble, x):
-        neighbors_X, neighbors_y = self.get_neighbors(x)
-
-        k = self.K
-
-        pool = []
-        while k > 0:
-            nn_X = neighbors_X[:k,:]
-            nn_y = neighbors_y[:k]
-
-            for i, c in enumerate(ensemble.classifiers):
-                if np.all(c.predict(nn_X) == nn_y[np.newaxis, :]):
-                    pool.append(c)
-
-            if not pool: # empty
-                k = k-1
-            else:
-                break
-
-        if not pool: # still empty
-            # select the classifier that recognizes
-            # more samples in the whole neighborhood
-            # also select classifiers that recognize
-            # the same number of neighbors
-            pool = self._get_best_classifiers(ensemble, neighbors_X, neighbors_y, x)
-
-
-        return Ensemble(classifiers=pool), None
-
-
-    def _get_best_classifiers(self, ensemble, neighbors_X, neighbors_y, x):
-        ensemble_out = ensemble.output(neighbors_X, mode='labels')
-        ensemble_mask = ensemble_out == neighbors_y[:,np.newaxis]
-
-        correct = np.sum(ensemble_mask, axis=0)
-        idx = np.argmax(correct) # best classifier idx
-
-        all_idx = correct == correct[idx]
-        
-        pool = [ensemble.classifiers[i] for i in all_idx]
-
-        return pool
 
 
 class KNORA_UNION(KNORA):
@@ -220,6 +209,15 @@ class KNORA_UNION(KNORA):
     Ko, Albert HR, Robert Sabourin, and Alceu Souza Britto Jr. 
     "From dynamic classifier selection to dynamic ensemble selection." 
     Pattern Recognition 41.5 (2008): 1718-1731.
+
+    Britto, Alceu S., Robert Sabourin, and Luiz ES Oliveira. 
+    "Dynamic selection of classifiers—A comprehensive review."
+    Pattern Recognition 47.11 (2014): 3665-3680.
+
+    Hung-Ren Ko, A., Robert Sabourin, and A. de Souza Britto. 
+    "K-nearest oracle for dynamic ensemble selection." 
+    Document Analysis and Recognition, 2007. ICDAR 2007. 
+    Ninth International Conference on. Vol. 1. IEEE, 2007.
     """
 
     def select(self, ensemble, x):
@@ -244,19 +242,6 @@ class KNORA_UNION(KNORA):
             weighted_votes = None
 
         return pool, weighted_votes
-
-class KNORA_UNION_2(KNORA):
-    
-    def select(self, ensemble, x):
-        neighbors_X, neighbors_y = self.get_neighbors(x)
-       
-        pool = []
-        for i, neighbor in enumerate(neighbors_X):
-            for c in ensemble.classifiers:
-                if c.predict(neighbor) == neighbors_y[i]:
-                    pool.append(c)
-
-        return Ensemble(classifiers=pool), None
 
 
 def _get_pool_mask(pool_output, neighbors_target, func):

--- a/brew/selection/dynamic/knora.py
+++ b/brew/selection/dynamic/knora.py
@@ -227,6 +227,7 @@ class KNORA_UNION(KNORA):
         output_mask = (pool_output == neighbors_y[:,np.newaxis])
 
         [selected_idx] = np.where(np.any(output_mask, axis=0))
+        print selected_idx
 
         if selected_idx.size > 0:
             if self.weighted:

--- a/examples/dcs.py
+++ b/examples/dcs.py
@@ -36,9 +36,9 @@ dcs_list = [OLA(X_val, y_val),
 dcs_names = ['ola', 'lca', 'KE', 'KU']
 
 
-print '------------------------------------------------'
+print('-----------------ERROR RATE----------------------')
 for dcs, name in zip(dcs_list, dcs_names):
     mcs = EnsembleClassifier(bag.ensemble, selector=dcs)
     y_pred = mcs.predict(X_test)
-    print name, zero_one_loss(y_pred, y_test)
-print '------------------------------------------------'
+    print('{}, {}'.format(name, zero_one_loss(y_pred, y_test)))
+print ('------------------------------------------------')

--- a/test/test_selection_dynamic.py
+++ b/test/test_selection_dynamic.py
@@ -33,22 +33,28 @@ Xtra, Xval, ytra, yval = train_test_split(Xtra, ytra, test_size=0.30)
 bag = Bagging(base_classifier=DecisionTreeClassifier(), n_classifiers=5)
 bag.fit(Xtra, ytra)
 
-class KNORA_UNION_2(KNORA):
+class KNORA_UNION_VALID(KNORA):
     
     def select(self, ensemble, x):
         neighbors_X, neighbors_y = self.get_neighbors(x)
        
         pool = []
-        for i, neighbor in enumerate(neighbors_X):
-            for c in ensemble.classifiers:
+        for c in ensemble.classifiers:
+            for i, neighbor in enumerate(neighbors_X):
                 if c.predict(neighbor) == neighbors_y[i]:
                     pool.append(c)
+                    break
 
-        return Ensemble(classifiers=pool), None
+        weights = []
+        for clf in pool:
+            msk = clf.predict(neighbors_X) == neighbors_y
+            weights = weights + [sum(msk)]
+
+        return Ensemble(classifiers=pool), weights
 
 
 
-class KNORA_ELIMINATE_2(KNORA):
+class KNORA_ELIMINATE_VALID(KNORA):
     def select(self, ensemble, x):
         neighbors_X, neighbors_y = self.get_neighbors(x)
 
@@ -81,7 +87,7 @@ class KNORA_ELIMINATE_2(KNORA):
 class TestKNORA_E():
     def test_simple(self):
         selector_pred = KNORA_ELIMINATE(Xval=Xval, yval=yval)
-        selector_true = KNORA_ELIMINATE_2(Xval=Xval, yval=yval)
+        selector_true = KNORA_ELIMINATE_VALID(Xval=Xval, yval=yval)
         for x in Xtst[:10]:
             pool_pred, w_pred = selector_pred.select(bag.ensemble, x)
             pool_true, w_true = selector_true.select(bag.ensemble, x)
@@ -94,7 +100,14 @@ class TestKNORA_E():
 class TestKNORA_U():
 
     def test_simple(self):
-        selector = KNORA_UNION(Xval=Xval, yval=yval)
-        for x in Xtst:
-            pool, w = selector.select(bag.ensemble, x)
+        selector_pred = KNORA_UNION(Xval=Xval, yval=yval)
+        selector_true = KNORA_UNION_VALID(Xval=Xval, yval=yval)
+        for x in Xtst[:10]:
+            pool_pred, w_pred = selector_pred.select(bag.ensemble, x)
+            pool_true, w_true = selector_true.select(bag.ensemble, x)
+            assert len(pool_pred) == len(pool_true)
+            for c_p, c_t in zip(pool_pred.classifiers, pool_true.classifiers):
+                assert c_p == c_t
+            assert len(w_pred) == len(w_true)
+            assert np.all(np.array(w_pred) == np.array(w_true))
 

--- a/test/test_selection_dynamic.py
+++ b/test/test_selection_dynamic.py
@@ -1,5 +1,5 @@
 """
-Tests for `brew.base` module.  """
+Tests for `brew.selection.dynamic` module.  """
 
 import numpy as np
 
@@ -33,11 +33,62 @@ Xtra, Xval, ytra, yval = train_test_split(Xtra, ytra, test_size=0.30)
 bag = Bagging(base_classifier=DecisionTreeClassifier(), n_classifiers=5)
 bag.fit(Xtra, ytra)
 
+class KNORA_UNION_2(KNORA):
+    
+    def select(self, ensemble, x):
+        neighbors_X, neighbors_y = self.get_neighbors(x)
+       
+        pool = []
+        for i, neighbor in enumerate(neighbors_X):
+            for c in ensemble.classifiers:
+                if c.predict(neighbor) == neighbors_y[i]:
+                    pool.append(c)
+
+        return Ensemble(classifiers=pool), None
+
+
+
+class KNORA_ELIMINATE_2(KNORA):
+    def select(self, ensemble, x):
+        neighbors_X, neighbors_y = self.get_neighbors(x)
+
+        k = self.K
+
+        pool = []
+        while k > 0:
+            nn_X = neighbors_X[:k,:]
+            nn_y = neighbors_y[:k]
+
+            for i, c in enumerate(ensemble.classifiers):
+                if np.all(c.predict(nn_X) == nn_y[np.newaxis, :]):
+                    pool.append(c)
+
+            if not pool: # empty
+                k = k-1
+            else:
+                break
+
+        if not pool: # still empty
+            # select the classifier that recognizes
+            # more samples in the whole neighborhood
+            # also select classifiers that recognize
+            # the same number of neighbors
+            pool = self._get_best_classifiers(ensemble, neighbors_X, neighbors_y, x)
+
+
+        return Ensemble(classifiers=pool), None
+
 class TestKNORA_E():
     def test_simple(self):
-        selector = KNORA_ELIMINATE(Xval=Xval, yval=yval)
-        for x in Xtst:
-            pool, w = selector.select(bag.ensemble, x)
+        selector_pred = KNORA_ELIMINATE(Xval=Xval, yval=yval)
+        selector_true = KNORA_ELIMINATE_2(Xval=Xval, yval=yval)
+        for x in Xtst[:10]:
+            pool_pred, w_pred = selector_pred.select(bag.ensemble, x)
+            pool_true, w_true = selector_true.select(bag.ensemble, x)
+            assert w_pred == w_true
+            assert len(pool_pred) == len(pool_true)
+            for c_p, c_t in zip(pool_pred.classifiers, pool_true.classifiers):
+                assert c_p == c_t
 
 
 class TestKNORA_U():


### PR DESCRIPTION
KNORA E with v2007 parameter in order to choose between the first proposal (2007) or the one with most citations (2008).
Removed non-numpy KNORA  and KNORA U from brew/selectino/dynamic/knora.py
Tests using naive pyhton implementation of KNORA to validate numpy implementation
DCS example knora compatible
