### PR TITLE
fixed IndexError that arises by using c.classes_ as np index in base.py

### DIFF
--- a/brew/base.py
+++ b/brew/base.py
@@ -185,8 +185,7 @@ class Ensemble(object):
 
             for i, c in enumerate(self.classifiers):
                 if mode == 'probs':
-                    probas = np.zeros((X.shape[0], n_classes))
-                    probas[:, list(c.classes_)] = c.predict_proba(X)
+                    probas= np.copy(c.predict_proba(X))
                     out[:, :, i] = probas
 
                 elif mode == 'votes':


### PR DESCRIPTION
Brew threw an Index Error at line 189 in base.py.
    187                 if mode == 'probs':
    188                     probas = np.zeros((X.shape[0], n_classes))
--> 189                     probas[:, list(c.classes_)] = c.predict_proba(X)
    190                     out[:, :, i] = probas
    191 

IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices

It looks like it i trying to use floats as column indices for probas.  this could be resolved by making change list(c.classes_) to list(c.classes.astype(int)) but I don't see the need to pre-create probas. 
