### PR TITLE
Rectified the error with MCB in dynamic selection

### DIFF
--- a/brew/selection/dynamic/mcb.py
+++ b/brew/selection/dynamic/mcb.py
@@ -92,7 +92,7 @@ class MCB(DCS):
         # use best_classifier
         best_i = np.argmax(scores)
         best_j_score = np.max(scores[np.arange(len(scores)) != best_i])
-        if scores[best_i] - scores[best_j] >= self.significance_threshold:
+        if scores[best_i] - scores[best_j_score] >= self.significance_threshold:
             best_classifier = ensemble.classifiers[best_i]
             return Ensemble(classifiers=[best_classifier]), None
 


### PR DESCRIPTION
In line 95 the earlier code was checking the `if condition` between `score[best_i]` and `score[best_j]` and it was giving an error as `best_j` was not defined. Since line 94 was using `best_j_score` so I changed the variable name from `best_j` to `best_j_score`.